### PR TITLE
Call callbacks in batch logging scenario once the request is sent or failed.

### DIFF
--- a/test/test_send.js
+++ b/test/test_send.js
@@ -590,9 +590,9 @@ describe("SplunkLogger send (integration tests)", function() {
 
             // Wrap sendevents to ensure it gets called
             var sendEvents = logger._sendEvents;
-            logger._sendEvents = function(cont, cb) {
+            logger._sendEvents = function(queue, cb) {
                 sent++;
-                sendEvents(cont, cb);
+                sendEvents(queue, cb);
             };
 
             logger.send(context);


### PR DESCRIPTION
Currently if the logger is configured for batch messaging, the callback for the send call is not being invoked except for messages that cause the batch limit to be reached. 

For context: This is currently causing a problem trying to create a transport for winston to connect logs to splunk when configuring this library to use batch sending. Since the initial callback is never invoked, only one log message will ever get sent.

This code change retains a reference to the callbacks for every message that is queued up, so that once the request is complete or fails, every message's callback that was sent or failed to send is invoked.