### PR TITLE
Added new config option with readme documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Splunk logging for JavaScript
 
-#### Version 0.10.1
+#### Version 0.10.2
 
 This project provides a simple JavaScript interface for logging to HTTP Event Collector in Splunk Enterprise and Splunk Cloud.
 
@@ -47,6 +47,25 @@ var Logger = new SplunkLogger(config);
 
 // Enable SSL certificate validation
 Logger.requestOptions.strictSSL = true;
+```
+
+### Configure Http Keep-Alive Agent
+
+Note: No default agent configuration is configured by default.
+To enable it, set `config.agent` to a valid http Agent (i.e. https://nodejs.org/api/http.html#http_new_agent_options)
+
+```javascript
+var SplunkLogger = require("splunk-logging").Logger;
+var Agent = require('http').Agent
+var agent = new Agent({ keepAlive: true })
+
+var config = {
+    token: "your-token-here",
+    url: "https://splunk.local:8088",
+    agent: agent,
+};
+
+var Logger = new SplunkLogger(config);
 ```
 
 ### Basic example

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "splunk-logging",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Splunk HTTP Event Collector logging interface",
   "homepage": "http://dev.splunk.com",
   "main": "index.js",

--- a/splunklogger.js
+++ b/splunklogger.js
@@ -434,6 +434,10 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
     // since json is set to true.
     requestOptions.headers["Content-Type"] = "application/x-www-form-urlencoded";
     requestOptions.url = this.config.protocol + "://" + this.config.host + ":" + this.config.port + this.config.path;
+    
+    if (this.config.agent) {
+        requestOptions.agent = this.config.agent;
+    }
 
     // Initialize the context again, right before using it
     context = this._initializeContext(context);


### PR DESCRIPTION
Adding this to allow us to configure an http/https agent for keep alive configurations. We've seen a large number of sockets being opened up by this library when used by our projects and believe it's due to not having configs available to update the request node module (which is now deprecated, btw, but that'll have to be another PR..). 

The example provides an usage example - but the simplicity of it would allow for using something more complex like this too: https://github.com/node-modules/agentkeepalive

Please let me know if you have questions or concerns.