### PR TITLE
update dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "needle": "^2.6.0"
+    "needle": "~2.8.0"
   },
   "devDependencies": {
     "nyc": "^15.1.0",


### PR DESCRIPTION
A bug was introduced into the `2.9.0` version of the `needle` dependency (the issue _erroneously_ indicates that it only effects node 8, but in fact, it impacts more recent node versions, e.g. node 14).  The needle bug was fixed in the `3.0.0` version.  

Unfortunately, the `"needle": "^2.6.0"` configuration means that by default `splunt-logging` is now installing the _broken_ version of needle.  This proposed change moves the dependency back to the latest working version while still allowing bug fix updates.  Alternatively, the dependency may be able to be updated to `"needle": "^3.0.0"`.

issue: https://github.com/tomas/needle/issues/371#issuecomment-908343537

v.3.0.0 changelog: https://github.com/tomas/needle/compare/v2.9.0...v3.0.0