### PR TITLE
Added support for fields in the metadata.

### DIFF
--- a/examples/all_batching.js
+++ b/examples/all_batching.js
@@ -59,6 +59,13 @@ var payload = {
         sourcetype: "httpevent",
         index: "main",
         host: "farm.local",
+        fields: {
+            device: "001",
+            sensors: [
+                "s44",
+                "s657"
+            ]
+        },
     },
     // Severity is also optional
     severity: "info"

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -49,7 +49,14 @@ var payload = {
         source: "chicken coop",
         sourcetype: "httpevent",
         index: "main",
-        host: "farm.local"
+        host: "farm.local",
+        fields: {
+            device: "001",
+            sensors: [
+                "s44",
+                "s657"
+            ]
+        },
     },
     // Severity is also optional
     severity: "info"
@@ -72,6 +79,10 @@ console.log("Sending payload", payload);
  *         "sourcetype": "httpevent",
  *         "index": "main",
  *         "host": "farm.local",
+ *         "fields": {
+ *             "device": "001",
+ *             "sensors": ["s44", "s657"]
+ *         },
  *         "event": {
  *             "message": {
  *                 "temperature": "70F",

--- a/examples/custom_format.js
+++ b/examples/custom_format.js
@@ -81,7 +81,14 @@ var payload = {
         source: "chicken coop",
         sourcetype: "httpevent",
         index: "main",
-        host: "farm.local"
+        host: "farm.local",
+        fields: {
+            device: "001",
+            sensors: [
+                "s44",
+                "s657"
+            ]
+        },
     },
     // Severity is also optional
     severity: "info"
@@ -104,6 +111,10 @@ console.log("Sending payload", payload);
  *         "sourcetype": "httpevent",
  *         "index": "main",
  *         "host": "farm.local",
+ *         "fields": {
+ *             "device": "001",
+ *             "sensors": ["s44", "s657"]
+ *         },
  *         "event": "[info]temperature=70F chickenCount=500 "
  *     }
  *

--- a/examples/manual_batching.js
+++ b/examples/manual_batching.js
@@ -56,7 +56,14 @@ var payload = {
         source: "chicken coop",
         sourcetype: "httpevent",
         index: "main",
-        host: "farm.local"
+        host: "farm.local",
+        fields: {
+            device: "001",
+            sensors: [
+                "s44",
+                "s657"
+            ]
+        },
     },
     // Severity is also optional
     severity: "info"

--- a/examples/retry.js
+++ b/examples/retry.js
@@ -56,7 +56,14 @@ var payload = {
         source: "chicken coop",
         sourcetype: "httpevent",
         index: "main",
-        host: "farm.local"
+        host: "farm.local",
+        fields: {
+            device: "001",
+            sensors: [
+                "s44",
+                "s657"
+            ]
+        },
     },
     // Severity is also optional
     severity: "info"

--- a/splunklogger.js
+++ b/splunklogger.js
@@ -349,6 +349,9 @@ SplunkLogger.prototype._initializeMetadata = function(context) {
         if (context.metadata.hasOwnProperty("index")) {
             metadata.index = context.metadata.index;
         }
+        if (context.metadata.hasOwnProperty("fields")) {
+            metadata.fields = context.metadata.fields;
+        }
     }
     return metadata;
 };
@@ -521,6 +524,13 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  *         sourcetype: "httpevent",
  *         index: "main",
  *         host: "farm.local",
+ *         fields: {
+ *             device: "001",
+ *             sensors: [
+ *                 "s44",
+ *                 "s657"
+ *             ]
+ *         },
  *     }
  * }; 
  *
@@ -543,6 +553,8 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  * If not specified, Splunk Enterprise or Splunk Cloud will decide the value.
  * @param {string} [context.metadata.source] - If not specified, Splunk Enterprise or Splunk Cloud will decide the value.
  * @param {string} [context.metadata.sourcetype] - If not specified, Splunk Enterprise or Splunk Cloud will decide the value.
+ * @param {string} [context.metadata.fields] - Specifies a JSON object that contains explicit custom fields to be defined at index time.
+ * If not specified, Splunk Enterprise or Splunk Cloud will decide the value.
  * @param {function} [callback] - A callback function: <code>function(err, response, body)</code>.
  * @throws Will throw an error if the <code>context</code> parameter is malformed.
  * @public

--- a/test/test_send.js
+++ b/test/test_send.js
@@ -383,6 +383,36 @@ describe("SplunkLogger send (integration tests)", function() {
                 done();
             });
         });
+        it("should succeed with valid token, changing fields", function(done) {
+            var config = {
+                token: TOKEN
+            };
+
+            var logger = new SplunkLogger(config);
+
+            var data = "something else";
+
+            var context = {
+                message: data,
+                metadata: {
+                    fields: {
+                        club: "glee",
+                        wins: [
+                            "regionals",
+                            "nationals"
+                        ]
+                    }
+                }
+            };
+
+            logger.send(context, function (err, resp, body) {
+                assert.ok(!err);
+                assert.strictEqual(resp.body, body);
+                assert.strictEqual(body.text, successBody.text);
+                assert.strictEqual(body.code, successBody.code);
+                done();
+            });
+        });
         it("should succeed with valid token", function(done) {
             var config = {
                 token: TOKEN


### PR DESCRIPTION
Should address issues #34 and #47 by adding `fields` as an expected value in `_initializeMetadata`.

Adds the `fields` to the root object in the POST request.

From the examples:
```javascript
var payload = {
  // Message can be anything; doesn't have to be an object
  message: {
    temperature: '70F',
    chickenCount: 500,
  },
  // Metadata is optional
  metadata: {
    source: 'chicken coop',
    sourcetype: 'httpevent',
    index: 'main',
    host: 'farm.local',
    fields: {
      device: '001',
      sensors: ['s44', 's657'],
    },
  },
  // Severity is also optional
  severity: 'info',
}
```

**Before** (generated POST body):

```json
{
  "host": "farm.local",
  "source": "chicken coop",
  "sourcetype": "httpevent",
  "index": "main",
  "time": "1631383981.764",
  "event": {
    "message": {
      "temperature": "70F",
      "chickenCount": 500
    },
    "severity": "info"
  }
}
```

**After** (generated POST body):

```json
{
  "host": "farm.local",
  "source": "chicken coop",
  "sourcetype": "httpevent",
  "index": "main",
  "fields": {
    "device": "001",
    "sensors": ["s44", "s657"]
  },
  "time": "1631382128.172",
  "event": {
    "message": {
      "temperature": "70F",
      "chickenCount": 500
    },
    "severity": "info"
  }
}
```

Tested against Splunk Enterprise, version `8.2.2`, build `87344edfcdb4`.