### PR TITLE
Add support for setting Content-Type header

### DIFF
--- a/splunklogger.js
+++ b/splunklogger.js
@@ -50,8 +50,8 @@ function _defaultEventFormatter(message, severity) {
 }
 
 /**
- * Constructs a SplunkLogger, to send events to Splunk Enterprise or Splunk Cloud 
- * via HTTP Event Collector. See <code>defaultConfig</code> for default 
+ * Constructs a SplunkLogger, to send events to Splunk Enterprise or Splunk Cloud
+ * via HTTP Event Collector. See <code>defaultConfig</code> for default
  * configuration settings.
  *
  * @example
@@ -83,7 +83,7 @@ function _defaultEventFormatter(message, severity) {
  * @param {string} [config.protocol=https] - Protocol used to communicate with the Splunk Enterprise or Splunk Cloud server, <code>http</code> or <code>https</code>.
  * @param {number} [config.port=8088] - HTTP Event Collector port on the Splunk Enterprise or Splunk Cloud server.
  * @param {string} [config.url] - URL string to pass to {@link https://nodejs.org/api/url.html#url_url_parsing|url.parse}. This will try to set
- * <code>host</code>, <code>path</code>, <code>protocol</code>, <code>port</code>, <code>url</code>. Any of these values will be overwritten if 
+ * <code>host</code>, <code>path</code>, <code>protocol</code>, <code>port</code>, <code>url</code>. Any of these values will be overwritten if
  * the corresponding property is set on <code>config</code>.
  * @param {string} [config.level=info] - Logging level to use, will show up as the <code>severity</code> field of an event, see
  *  [SplunkLogger.levels]{@link SplunkLogger#levels} for common levels.
@@ -135,6 +135,7 @@ SplunkLogger.prototype.levels = {
 };
 
 var defaultConfig = {
+    contentType: "application/x-www-form-urlencoded",
     name: "splunk-javascript-logging/0.11.1",
     host: "localhost",
     path: "/services/collector/event/1.0",
@@ -180,7 +181,7 @@ SplunkLogger.prototype._enableTimer = function(interval) {
     if (this._timerID) {
         this._disableTimer();
     }
-    
+
     // If batch interval is changed, update the config property
     if (this.config) {
         this.config.batchInterval = interval;
@@ -275,7 +276,7 @@ SplunkLogger.prototype._initializeConfig = function(config) {
         var startTimer = !this._timerID && ret.batchInterval > 0;
         // Has the interval timer already started, and the interval changed to a different duration?
         var changeTimer = this._timerID && this._timerDuration !== ret.batchInterval && ret.batchInterval > 0;
-        
+
         // Enable the timer
         if (startTimer || changeTimer) {
             this._enableTimer(ret.batchInterval);
@@ -284,6 +285,9 @@ SplunkLogger.prototype._initializeConfig = function(config) {
         else if (this._timerID && (ret.batchInterval <= 0 || this._timerDuration < 0)) {
             this._disableTimer();
         }
+
+        // Allow Content-Type header override from config
+        ret.contentType = utils.orByFalseyProp("contentType", config, ret, defaultConfig);
     }
     return ret;
 };
@@ -397,7 +401,7 @@ SplunkLogger.prototype._makeBody = function(context) {
     var body = this._initializeMetadata(context);
     var time = utils.formatTime(body.time || Date.now());
     body.time = time.toString();
-    
+
     body.event = this.eventFormatter(context.message, context.severity || defaultConfig.level);
     return body;
 };
@@ -436,7 +440,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
     requestOptions.headers["Authorization"] = "Splunk " + this.config.token;
     // Manually set the content-type header, the default is application/json
     // since json is set to true.
-    requestOptions.headers["Content-Type"] = "application/x-www-form-urlencoded";
+    requestOptions.headers["Content-Type"] = this.config.contentType;
     requestOptions.url = this.config.protocol + "://" + this.config.host + ":" + this.config.port + this.config.path;
 
     // Initialize the context again, right before using it
@@ -496,7 +500,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
         }
     );
 };
- 
+
 /**
  * Sends or queues data to be sent based on batching settings.
  * Default behavior is to send immediately.
@@ -505,8 +509,8 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  * var SplunkLogger = require("splunk-logging").Logger;
  * var config = {
  *     token: "your-token-here"
- * }; 
- * 
+ * };
+ *
  * var logger = new SplunkLogger(config);
  *
  * // Payload to send to HTTP Event Collector.
@@ -522,7 +526,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  *         index: "main",
  *         host: "farm.local",
  *     }
- * }; 
+ * };
  *
  * // The callback is only used if maxBatchCount=1, or
  * // batching thresholds have been exceeded.
@@ -549,7 +553,7 @@ SplunkLogger.prototype._sendEvents = function(context, callback) {
  */
 SplunkLogger.prototype.send = function(context, callback) {
     context = this._initializeContext(context);
-    
+
     // Store the context, and its estimated length
     var currentEvent = JSON.stringify(this._makeBody(context));
     this.serializedContextQueue.push(currentEvent);
@@ -583,7 +587,7 @@ SplunkLogger.prototype.flush = function(callback) {
     var context = {
         message: data
     };
-    
+
     this._sendEvents(context, callback);
 };
 

--- a/test/test_config.js
+++ b/test/test_config.js
@@ -843,6 +843,25 @@ describe("SplunkLogger", function() {
             assert.strictEqual(0, loggerConfig.batchInterval);
             assert.strictEqual(0, loggerConfig.maxBatchSize);
         });
+        it("should use the default contentType if not overriden", function() {
+            var config = {
+                token: "a-token-goes-here-usually",
+                url: "splunk.local"
+            };
+            var loggerConfig = SplunkLogger.prototype._initializeConfig(config);
+
+            assert.strictEqual("application/x-www-form-urlencoded", loggerConfig.contentType);
+        });
+        it("should set the contentType if overriden", function() {
+            var config = {
+                token: "a-token-goes-here-usually",
+                url: "splunk.local",
+                contentType: "application/json"
+            };
+            var loggerConfig = SplunkLogger.prototype._initializeConfig(config);
+
+            assert.strictEqual("application/json", loggerConfig.contentType);
+        });
     });
     describe("_initializeRequestOptions", function() {
         it("should get defaults with no args", function() {


### PR DESCRIPTION
We'd like to use this library to send logs to the Splunk Log Observer framework. This requires setting a Content-Type header of `application/json`, instead of `application/x-www-form-urlencoded`. This PR should add support for us to set that via config